### PR TITLE
keep CherryPy at version 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN \
  echo "**** install gazee ****" && \
  git clone --depth 1 https://github.com/hubbcaps/gazee.git /app/gazee && \
  sed -i \
-	's/==/>=/g' \
+	'/^CherryPy/!s/==/>=/g' \
 	/app/gazee/requirements.txt && \
  pip install --no-cache-dir -U \
 	-r /app/gazee/requirements.txt && \

--- a/README.md
+++ b/README.md
@@ -101,4 +101,5 @@ Happy Reading!
 
 ## Versions
 
++ **30.12.17:** Ensure version 11 of cherrypy.
 + **07.12.17:** Initial Release.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

fixes cherrypy errors when using cherrypy version 12 
re :-  https://github.com/hubbcaps/gazee/issues/50